### PR TITLE
Various bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.bak
+*~
 **/compiled

--- a/Bits.rkt
+++ b/Bits.rkt
@@ -6,13 +6,13 @@
 
 (provide (all-defined-out))
 
-(define endianess #t)
+(define endianess #f)
 (define max-memory-size 8192) ;; Arbitrary
 
 (define memory-size bit-string-byte-count)
 
 (define (make-memory size)
-  (bit-string (0 :: big-endian bytes size)))
+  (bit-string (0 :: little-endian bytes size)))
 
 (define (grow-memory mem newsize)
   (if (<= 0 newsize max-memory-size)

--- a/Semantics.rkt
+++ b/Semantics.rkt
@@ -69,12 +69,11 @@
           (where (v_2 ...) ,(drop-right (term (v_1 ...)) (length (term (t_1 ...)))))
           (where (v_3 ...) ,(take-right (term (v_1 ...)) (length (term (t_1 ...))))))
 
-     (--> (s j (v ...) (in-hole L (v_1 ... (label () (v_2 ... (trap) e ...)) e_2 ...)))
-          (s j (v ...) (in-hole L ((trap)))))
+     (--> (s j (v ...) (in-hole L (v_1 ... (label (e ...) ((trap))) e_2 ...)))
+          (s j (v ...) (in-hole L (v_1 ... (trap) e_2 ...))))
 
      (--> (s j (v ...) (in-hole L (v_1 ... (trap) e_2 ...)))
-          (s j (v ...) (in-hole L ((trap))))
-          (side-condition (= 0 (term (context-depth L)))))
+          (s j (v ...) (in-hole L ((trap)))))
 
      ; Knowing about contexts is necessary for this (so can't shortcut the rest :/)!
      (--> (s j (v ...) (in-hole L (v_1 ... (br j_1) e ...)))
@@ -125,11 +124,11 @@
      ; Stuff inside functions calls
      ;; TODO: Can we assume v_3 ... is the right arity and types to return?
      ;; NOTE: This is fun decomposition...
-     (--> (s j (v ...) (in-hole L (v_1 ... (local (j_1 (v_2 ...)) (in-hole L_2 (v_3 ... (return) e ...)) e_2 ...))))
+     (--> (s j (v ...) (in-hole L (v_1 ... (local (j_1 (v_2 ...)) (in-hole L_2 (v_3 ... (return) e ...))) e_2 ...)))
           (s j (v ...) (in-hole L (v_1 ... v_3 ... e_2 ...))))
 
-     (--> (s j (v ...) (in-hole L (v_1 ... (local (j_1 (v_2 ...)) (v_3 ... (trap) e ...)) e_2 ...)))
-          (s j (v ...) (in-hole L ((trap)))))
+     (--> (s j (v ...) (in-hole L (v_1 ... (local (j_1 (v_2 ...)) ((trap))) e_2 ...)))
+          (s j (v ...) (in-hole L (v_1 ... (trap) e_2 ...))))
 
      ;; TODO: Can we assume v_3 ... has the right arity and types to return?
      (--> (s j (v ...) (in-hole L (v_1 ... (local (j_1 (v_2 ...)) (v_3 ...)) e_2 ...)))

--- a/Utilities.rkt
+++ b/Utilities.rkt
@@ -58,7 +58,7 @@
   decompose : L j (v ...) -> (e ...)
   [(decompose (v ... (label (e ...) L_1) e_2 ...) j (v_2 ...))
    (v ... v_2 ... e ... e_2 ...)
-   (side-condition (>= (term j) (term (context-depth L_1))))]
+   (side-condition (= (term j) (term (context-depth L_1))))]
   [(decompose (v ... (label (e ...) L_1) e_2 ...) j (v_2 ...))
    (v ... (label (e ...) (decompose L_1 j (v_2 ...))) e_2 ...)
    (side-condition (< (term j) (term (context-depth L_1))))])


### PR DESCRIPTION
- Fix reductions of trap inside labels and locals
- Fix misplaced paren in reduction of return statments
- Changed endianess to little endian to match paper
- Changed >= to = in decompose so branching errors if ill-formed