### PR TITLE
Various reduction rule bugfixes

### DIFF
--- a/Semantics.rkt
+++ b/Semantics.rkt
@@ -53,7 +53,7 @@
           (s j (v ...) (in-hole L (v_1 ... e ...))))
      
      (--> (s j (v ...) (in-hole L (v_1 ... (i32 const 0) (if tf (e_1 ...) else (e_2 ...)) e ...)))
-          (s j (v ...) (in-hole L (v_1 ... (block tf (e_1 ...)) e ...))))
+          (s j (v ...) (in-hole L (v_1 ... (block tf (e_2 ...)) e ...))))
 
      (--> (s j (v ...) (in-hole L (v_1 ... (i32 const c) (if tf (e_1 ...) else (e_2 ...)) e ...)))
           (s j (v ...) (in-hole L (v_1 ... (block tf (e_1 ...)) e ...)))

--- a/Semantics.rkt
+++ b/Semantics.rkt
@@ -94,7 +94,7 @@
           (s j (v ...) (in-hole L (v_1 ... v_2 (br j_2) e ...)))
           (side-condition (> (term c) (length (term (j_1 ...))))))
 
-     (--> (s j (v ...) (in-hole L (v_1 ... (label () (v_2 ...)) e ...)))
+     (--> (s j (v ...) (in-hole L (v_1 ... (label (e_1 ...) (v_2 ...)) e ...)))
           (s j (v ...) (v_1 ... v_2 ... e ...)))
 
      ;; Locals!

--- a/Semantics.rkt
+++ b/Semantics.rkt
@@ -101,11 +101,11 @@
      (--> (s j (v ...) (in-hole L (v_1 ... (get-local j_1) e ...)))
           (s j (v ...) (in-hole L (v_1 ... (do-get (v ...) j_1) e ...))))
      
-     (--> (s j (v ...) (in-hole L (v_1 ... v_2 (set-local j) e ...)))
-          (s j (do-set (v ...) j v_2) (in-hole L (v_1 ... e ...))))
+     (--> (s j (v ...) (in-hole L (v_1 ... v_2 (set-local j_1) e ...)))
+          (s j (do-set (v ...) j_1 v_2) (in-hole L (v_1 ... e ...))))
 
-     (--> (s j (v ...) (in-hole L (v_1 ... v_2 (tee-local j) e ...)))
-          (s j (v ...) (in-hole L (v_1 ... v_2 v_2 (set-local j) e ...))))
+     (--> (s j (v ...) (in-hole L (v_1 ... v_2 (tee-local j_1) e ...)))
+          (s j (v ...) (in-hole L (v_1 ... v_2 v_2 (set-local j_1) e ...))))
 
      ;; Store stuff!
      (--> (((inst ...) (tabinst ...) (meminst ...)) j (v ...) (in-hole L (v_1 ... (get-global j_1) e ...)))

--- a/Tests/SemanticTests.rkt
+++ b/Tests/SemanticTests.rkt
@@ -127,6 +127,16 @@
                     () ; locals
                     ())))
 
+  (test-->>E -> ;; call cl, return ensure branching with instructions after local
+             (term ((() () ()) ; store
+                    0 ; inst
+                    () ; locals
+                    ((call (0 (() (func (() -> (i32)) (local () ((i32 const 42) (return) (unreachable))))))) (i32 const 2) (i32 add))))
+             (term ((() () ()) ; store
+                    0 ; inst
+                    () ; locals
+                    ((i32 const 44)))))
+
   (test-->>E -> ;; call_indirect
              (term ((((() () (table 1) (memory)))
                     (((0 (() (func ((i32) -> (i32)) (local () ((get-local 0) (return))))))
@@ -245,7 +255,7 @@
                     ()
                     ((i32 const 2)))))
 
-    (test-->>E -> ;; if-false
+  (test-->>E -> ;; if-false
              (term ((() () ())
                     0
                     ()
@@ -258,7 +268,17 @@
                     0
                     ()
                     ((i32 const 3)))))
-  
+
+  (test-->>E -> ;; loop with trap (trap inside label with instructions)
+             (term ((() () ())
+                    0
+                    ()
+                    ((loop (() -> ())
+                           ((unreachable))))))
+             (term ((() () ())
+                    0
+                    ()
+                    ((trap)))))
 
   (test-->>E -> ;; loop, if
                (term ((((((0 (() (func ((i32) -> (i32))

--- a/Tests/SemanticTests.rkt
+++ b/Tests/SemanticTests.rkt
@@ -199,6 +199,24 @@
                     ()
                     ((i64 const 65)))))
 
+  (test-->>E -> ;; store i32, load i8 (test of endianness)
+             (term ((((() () (table) (memory 0)))
+                     ()
+                     ((bits ,(make-memory 128))))
+                    0
+                    ()
+                    ((i32 const 0)
+                     (i32 const 0)
+                     (i32 const 305419896) ; 0x12345678
+                     (i32 store 0 4)
+                     (i32 load (i8 unsigned) 0 4))))
+             (term ((((() () (table) (memory 0)))
+                     ()
+                     ((bits ,(store (make-memory 128) 32 32 305419896))))
+                    0
+                    ()
+                    ((i32 const 120))))) ; 0x78, would be 0x12 if big-endian
+
   (test-->>E -> ;; store out-of-bounds than load
              (term ((((() () (table) (memory 0)))
                      ()

--- a/Tests/SemanticTests.rkt
+++ b/Tests/SemanticTests.rkt
@@ -260,7 +260,7 @@
                     ((i32 const 3)))))
   
 
-  #;(test-->>E -> ;; loop, if
+  (test-->>E -> ;; loop, if
                (term ((((((0 (() (func ((i32) -> (i32))
                                        (local (i32) ((loop (() -> (i32))
                                                            ((get-local 0)

--- a/Tests/SemanticTests.rkt
+++ b/Tests/SemanticTests.rkt
@@ -61,22 +61,22 @@
   ;; Tests of function calls
   (test-->>E -> ;; call j, call cl, get-local, return
              (term ((((() () (table) (memory))
-                     (((0 (() (func ((i32) -> ()) (local () ((get-local 0))))))
-                       (1 (() (func ((i32 i32) -> ()) (local () ((get-local 1))))))
-                       (2 (() (func ((i32 i32 i32) -> ()) (local () ((get-local 2)))))))
-                      () (table) (memory))
-                     (() ()  (table) (memory)))
+                      (((0 (() (func ((i32) -> ()) (local () ((get-local 0))))))
+                        (1 (() (func ((i32 i32) -> ()) (local () ((get-local 1))))))
+                        (2 (() (func ((i32 i32 i32) -> ()) (local () ((get-local 2)))))))
+                       () (table) (memory))
+                      (() ()  (table) (memory)))
                      ()
                      ()) ; store
                     1 ; inst
                     () ; locals
                     ((i32 const 0) (i32 const 1) (i32 const 2) (call 1)))) ; e stream
              (term ((((() () (table) (memory))
-                     (((0 (() (func ((i32) -> ()) (local () ((get-local 0))))))
-                       (1 (() (func ((i32 i32) -> ()) (local () ((get-local 1))))))
-                       (2 (() (func ((i32 i32 i32) -> ()) (local () ((get-local 2)))))))
-                      () (table) (memory))
-                     (() ()  (table) (memory)))
+                      (((0 (() (func ((i32) -> ()) (local () ((get-local 0))))))
+                        (1 (() (func ((i32 i32) -> ()) (local () ((get-local 1))))))
+                        (2 (() (func ((i32 i32 i32) -> ()) (local () ((get-local 2)))))))
+                       () (table) (memory))
+                      (() ()  (table) (memory)))
                      ()
                      ()) ; store
                     1 ; inst
@@ -230,4 +230,75 @@
                     0
                     ()
                     ((i32 const 128)))))
+
+  (test-->>E -> ;; if-true
+             (term ((() () ())
+                    0
+                    ()
+                    ((i32 const 1)
+                     (if (() -> (i32))
+                         ((i32 const 2))
+                         else
+                         ((i32 const 3))))))
+             (term ((() () ())
+                    0
+                    ()
+                    ((i32 const 2)))))
+
+    (test-->>E -> ;; if-false
+             (term ((() () ())
+                    0
+                    ()
+                    ((i32 const 0)
+                     (if (() -> (i32))
+                         ((i32 const 2))
+                         else
+                         ((i32 const 3))))))
+             (term ((() () ())
+                    0
+                    ()
+                    ((i32 const 3)))))
+  
+
+  #;(test-->>E -> ;; loop, if
+               (term ((((((0 (() (func ((i32) -> (i32))
+                                       (local (i32) ((loop (() -> (i32))
+                                                           ((get-local 0)
+                                                            (if (() -> (i32))
+                                                                ((get-local 0)
+                                                                 (get-local 1)
+                                                                 (i32 add)
+                                                                 (set-local 1)
+                                                                 (get-local 0)
+                                                                 (i32 const 1)
+                                                                 (i32 sub)
+                                                                 (set-local 0)
+                                                                 (br 1))
+                                                                else
+                                                                ((get-local 1)))))))))))
+                         () (table) (memory))) ; store
+                       () ())
+                      0
+                      ()
+                      ((i32 const 5) (call 0))))
+             (term ((((((0 (() (func ((i32) -> (i32))
+                                     (local (i32) ((loop (() -> (i32))
+                                                         ((get-local 0)
+                                                          (if (() -> (i32))
+                                                              ((get-local 0)
+                                                               (get-local 1)
+                                                               (i32 add)
+                                                               (set-local 1)
+                                                               (get-local 0)
+                                                               (i32 const 1)
+                                                               (i32 sub)
+                                                               (set-local 0)
+                                                               (br 1))
+                                                              else
+                                                              ((get-local 1)))))))))))
+                       () (table) (memory))) ; store
+                     () ())
+                    0
+                    ()
+                    ((i32 const 15)))))
   )


### PR DESCRIPTION
Fixes #3 
- Fixed set-local and tee-local reduction relation rules reusing `j`
- Reduce labels with instructions that have been reduced to values
- Properly reduce if-false
- Added endianness test